### PR TITLE
Upgrade NextJS to 15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@iconify-icon/react": "^2.3.0",
         "@prisma/client": "^6.4.1",
         "framer-motion": "^11.18.1",
-        "next": "^15.1.7",
+        "next": "^15.2.0",
         "next-themes": "^0.4.4",
         "prisma": "^6.4.1",
         "react": "^19.0.0",
@@ -2923,9 +2923,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.7.tgz",
-      "integrity": "sha512-d9jnRrkuOH7Mhi+LHav2XW91HOgTAWHxjMPkXMGBc9B2b7614P7kjt8tAplRvJpbSt4nbO1lugcT/kAaWzjlLQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.0.tgz",
+      "integrity": "sha512-eMgJu1RBXxxqqnuRJQh5RozhskoNUDHBFybvi+Z+yK9qzKeG7dadhv/Vp1YooSZmCnegf7JxWuapV77necLZNA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.7.tgz",
-      "integrity": "sha512-hPFwzPJDpA8FGj7IKV3Yf1web3oz2YsR8du4amKw8d+jAOHfYHYFpMkoF6vgSY4W6vB29RtZEklK9ayinGiCmQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.0.tgz",
+      "integrity": "sha512-rlp22GZwNJjFCyL7h5wz9vtpBVuCt3ZYjFWpEPBGzG712/uL1bbSkS675rVAUCRZ4hjoTJ26Q7IKhr5DfJrHDA==",
       "cpu": [
         "arm64"
       ],
@@ -2955,9 +2955,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.7.tgz",
-      "integrity": "sha512-2qoas+fO3OQKkU0PBUfwTiw/EYpN+kdAx62cePRyY1LqKtP09Vp5UcUntfZYajop5fDFTjSxCHfZVRxzi+9FYQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.0.tgz",
+      "integrity": "sha512-DiU85EqSHogCz80+sgsx90/ecygfCSGl5P3b4XDRVZpgujBm5lp4ts7YaHru7eVTyZMjHInzKr+w0/7+qDrvMA==",
       "cpu": [
         "x64"
       ],
@@ -2971,9 +2971,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.7.tgz",
-      "integrity": "sha512-sKLLwDX709mPdzxMnRIXLIT9zaX2w0GUlkLYQnKGoXeWUhcvpCrK+yevcwCJPdTdxZEUA0mOXGLdPsGkudGdnA==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.0.tgz",
+      "integrity": "sha512-VnpoMaGukiNWVxeqKHwi8MN47yKGyki5q+7ql/7p/3ifuU2341i/gDwGK1rivk0pVYbdv5D8z63uu9yMw0QhpQ==",
       "cpu": [
         "arm64"
       ],
@@ -2987,9 +2987,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.7.tgz",
-      "integrity": "sha512-zblK1OQbQWdC8fxdX4fpsHDw+VSpBPGEUX4PhSE9hkaWPrWoeIJn+baX53vbsbDRaDKd7bBNcXRovY1hEhFd7w==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.0.tgz",
+      "integrity": "sha512-ka97/ssYE5nPH4Qs+8bd8RlYeNeUVBhcnsNUmFM6VWEob4jfN9FTr0NBhXVi1XEJpj3cMfgSRW+LdE3SUZbPrw==",
       "cpu": [
         "arm64"
       ],
@@ -3003,9 +3003,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.7.tgz",
-      "integrity": "sha512-GOzXutxuLvLHFDAPsMP2zDBMl1vfUHHpdNpFGhxu90jEzH6nNIgmtw/s1MDwpTOiM+MT5V8+I1hmVFeAUhkbgQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.0.tgz",
+      "integrity": "sha512-zY1JduE4B3q0k2ZCE+DAF/1efjTXUsKP+VXRtrt/rJCTgDlUyyryx7aOgYXNc1d8gobys/Lof9P9ze8IyRDn7Q==",
       "cpu": [
         "x64"
       ],
@@ -3019,9 +3019,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.7.tgz",
-      "integrity": "sha512-WrZ7jBhR7ATW1z5iEQ0ZJfE2twCNSXbpCSaAunF3BKcVeHFADSI/AW1y5Xt3DzTqPF1FzQlwQTewqetAABhZRQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.0.tgz",
+      "integrity": "sha512-QqvLZpurBD46RhaVaVBepkVQzh8xtlUN00RlG4Iq1sBheNugamUNPuZEH1r9X1YGQo1KqAe1iiShF0acva3jHQ==",
       "cpu": [
         "x64"
       ],
@@ -3035,9 +3035,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.7.tgz",
-      "integrity": "sha512-LDnj1f3OVbou1BqvvXVqouJZKcwq++mV2F+oFHptToZtScIEnhNRJAhJzqAtTE2dB31qDYL45xJwrc+bLeKM2Q==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.0.tgz",
+      "integrity": "sha512-ODZ0r9WMyylTHAN6pLtvUtQlGXBL9voljv6ujSlcsjOxhtXPI1Ag6AhZK0SE8hEpR1374WZZ5w33ChpJd5fsjw==",
       "cpu": [
         "arm64"
       ],
@@ -3051,9 +3051,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.7.tgz",
-      "integrity": "sha512-dC01f1quuf97viOfW05/K8XYv2iuBgAxJZl7mbCKEjMgdQl5JjAKJ0D2qMKZCgPWDeFbFT0Q0nYWwytEW0DWTQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.0.tgz",
+      "integrity": "sha512-8+4Z3Z7xa13NdUuUAcpVNA6o76lNPniBd9Xbo02bwXQXnZgFvEopwY2at5+z7yHl47X9qbZpvwatZ2BRo3EdZw==",
       "cpu": [
         "x64"
       ],
@@ -8067,12 +8067,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.1.7.tgz",
-      "integrity": "sha512-GNeINPGS9c6OZKCvKypbL8GTsT5GhWPp4DM0fzkXJuXMilOO2EeFxuAY6JZbtk6XIl6Ws10ag3xRINDjSO5+wg==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.0.tgz",
+      "integrity": "sha512-VaiM7sZYX8KIAHBrRGSFytKknkrexNfGb8GlG6e93JqueCspuGte8i4ybn8z4ww1x3f2uzY4YpTaBEW4/hvsoQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.1.7",
+        "@next/env": "15.2.0",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -8087,14 +8087,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.1.7",
-        "@next/swc-darwin-x64": "15.1.7",
-        "@next/swc-linux-arm64-gnu": "15.1.7",
-        "@next/swc-linux-arm64-musl": "15.1.7",
-        "@next/swc-linux-x64-gnu": "15.1.7",
-        "@next/swc-linux-x64-musl": "15.1.7",
-        "@next/swc-win32-arm64-msvc": "15.1.7",
-        "@next/swc-win32-x64-msvc": "15.1.7",
+        "@next/swc-darwin-arm64": "15.2.0",
+        "@next/swc-darwin-x64": "15.2.0",
+        "@next/swc-linux-arm64-gnu": "15.2.0",
+        "@next/swc-linux-arm64-musl": "15.2.0",
+        "@next/swc-linux-x64-gnu": "15.2.0",
+        "@next/swc-linux-x64-musl": "15.2.0",
+        "@next/swc-win32-arm64-msvc": "15.2.0",
+        "@next/swc-win32-x64-msvc": "15.2.0",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@iconify-icon/react": "^2.3.0",
     "@prisma/client": "^6.4.1",
     "framer-motion": "^11.18.1",
-    "next": "^15.1.7",
+    "next": "^15.2.0",
     "next-themes": "^0.4.4",
     "prisma": "^6.4.1",
     "react": "^19.0.0",


### PR DESCRIPTION
This pull request includes an update to the `next` package version in the `package.json` file.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R21): Updated the `next` package version from `^15.1.7` to `^15.2.0`.